### PR TITLE
Upgrade airflow chart

### DIFF
--- a/services/scheduler/create-web-secrets.sh
+++ b/services/scheduler/create-web-secrets.sh
@@ -1,5 +1,5 @@
 NS=scheduler
 WEBSERVER_SECRET=$(op read op://vandelay/airflow/webserver)
-kubectl create secret generic webserver-key \
-    --from-literal="webserver-secret-key=$WEBSERVER_SECRET" \
+kubectl create secret generic api-key \
+    --from-literal="api-secret-key=$WEBSERVER_SECRET" \
     --namespace=$NS

--- a/services/scheduler/install-upgrade.sh
+++ b/services/scheduler/install-upgrade.sh
@@ -3,4 +3,4 @@ helm upgrade \
     --install airflow apache-airflow/airflow \
     --namespace scheduler \
     --values services/scheduler/values-v3.yaml \
-    --version 1.17.0
+    --version 1.18.0

--- a/services/scheduler/values-v3.yaml
+++ b/services/scheduler/values-v3.yaml
@@ -1,4 +1,4 @@
-webserverSecretKeySecretName: webserver-key
+apiSecretKeySecretName: api-key
 fernetKeySecretName: metadata-fernet-key
 images:
   airflow:


### PR DESCRIPTION
- chart is moving away from `webserverSecretKeySecretName` into `apiSecretKeySecretName`
- beyond that, the key in the secret has to be `api-secret-key`.
